### PR TITLE
Let terraform initialize the first task definition

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,7 +1,7 @@
 name: pull-request
 run-name: Test and validate pull request done by ${{ github.actor }} on ${{ github.head_ref }} branch
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 on:
   pull_request:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -9,7 +9,8 @@ on:
       - 'src/**'
       - 'tests/**'
       - 'infrastructure/Dockerfile'
-      - '.github/workflows/**'
+      - '.github/workflows/deploy.yaml'
+      - '.github/workflows/pull-request.yaml'
 jobs:
   build-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/terraform-pull-request.yaml
+++ b/.github/workflows/terraform-pull-request.yaml
@@ -1,7 +1,7 @@
 name: terraform-pull-request
 run-name: Terraform pull request done by ${{ github.actor }} on ${{ github.head_ref }} branch
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 on:
   pull_request:

--- a/infrastructure/ecs.tf
+++ b/infrastructure/ecs.tf
@@ -28,7 +28,7 @@ resource "aws_ecs_task_definition" "initiator" {
   network_mode             = "awsvpc"
 }
 
-resource "aws_ecs_service" "this" {
+resource "aws_ecs_service" "ecs_service" {
   name        = local.service
   cluster     = aws_ecs_cluster.this.id
   launch_type = "FARGATE"

--- a/infrastructure/load-balancer.tf
+++ b/infrastructure/load-balancer.tf
@@ -1,6 +1,12 @@
+resource "aws_lb" "this" {
+  name            = "${local.service}-alb"
+  security_groups = [aws_security_group.this.id]
+  subnets         = data.aws_subnets.this.ids
+}
+
 # Remove this when when we have a proper DNS
 resource "aws_acm_certificate" "temporary" {
-  domain_name       = "*.amazonaws.com"
+  domain_name       = aws_lb.this.dns_name
   validation_method = "DNS"
 
   tags = {
@@ -10,12 +16,6 @@ resource "aws_acm_certificate" "temporary" {
   lifecycle {
     create_before_destroy = true
   }
-}
-
-resource "aws_lb" "this" {
-  name            = "${local.service}-alb"
-  security_groups = [aws_security_group.this.id]
-  subnets         = data.aws_subnets.this.ids
 }
 
 resource "aws_lb_listener" "this" {

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -47,5 +47,5 @@ output "iam_task_arn" {
 }
 
 output "aws_ecs_service" {
-  value = aws_ecs_service.this.id
+  value = aws_ecs_service.ecs_service.id
 }


### PR DESCRIPTION
When initializing the ecs service it needs an existing task definition.

> creating ECS Service (clean-slice): InvalidParameterException: TaskDefinition can not be blank.

So we'll just set a dummy one first and allow the pipeline to deploy the actual container