### PR TITLE
Change load balancer to HTTPS to HTTP

### DIFF
--- a/infrastructure/ecs.tf
+++ b/infrastructure/ecs.tf
@@ -23,6 +23,8 @@ resource "aws_ecs_task_definition" "initiator" {
       ]
     }]
   )
+  cpu    = 256
+  memory = 512
 
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"

--- a/infrastructure/load-balancer.tf
+++ b/infrastructure/load-balancer.tf
@@ -4,39 +4,6 @@ resource "aws_lb" "this" {
   subnets         = data.aws_subnets.this.ids
 }
 
-# Remove this when when we have a proper DNS
-resource "aws_acm_certificate" "temporary" {
-  domain_name       = aws_lb.this.dns_name
-  validation_method = "DNS"
-
-  tags = {
-    Environment = "Temporary"
-  }
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
-resource "aws_lb_listener" "this" {
-  load_balancer_arn = aws_lb.this.arn
-
-  port            = "443"
-  protocol        = "HTTPS"
-  ssl_policy      = "ELBSecurityPolicy-2016-08"
-  certificate_arn = aws_acm_certificate.temporary.arn
-
-  default_action {
-    type = "fixed-response"
-
-    fixed_response {
-      content_type = "text/plain"
-      message_body = "Sorry, we could not find the resource you were looking for. Please check your request and try again."
-      status_code  = "404"
-    }
-  }
-}
-
 resource "aws_lb_target_group" "this" {
   name        = "${local.service}-lb-tg"
   port        = 80
@@ -52,6 +19,42 @@ resource "aws_lb_target_group" "this" {
     timeout             = 10
     healthy_threshold   = 3
     unhealthy_threshold = 3
+  }
+}
+
+# TODO generate cert for HTTPS when we actually have a domain ready
+# resource "aws_acm_certificate" "temporary" {
+#   domain_name       = aws_lb.this.dns_name
+#   validation_method = "DNS"
+
+#   tags = {
+#     Environment = "Temporary"
+#   }
+
+#   lifecycle {
+#     create_before_destroy = true
+#   }
+# }
+
+resource "aws_lb_listener" "this" {
+  load_balancer_arn = aws_lb.this.arn
+
+  port     = "80"
+  protocol = "HTTP"
+  # TODO make it HTTPS when we actually have a domain ready
+  # port            = "443"
+  # protocol        = "HTTPS"
+  # certificate_arn = aws_acm_certificate.temporary.arn
+  ssl_policy = "ELBSecurityPolicy-2016-08"
+
+  default_action {
+    type = "fixed-response"
+
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "Sorry, we could not find the resource you were looking for. Please check your request and try again."
+      status_code  = "404"
+    }
   }
 }
 


### PR DESCRIPTION
This is momentarily and for first setup purpose.

If i had a domain i guess this wouldn't be a problem.

But it puzzles me that AWS would allow my load balancer to be unprotected and not have a certificate i can link to that already exist on the domain