### PR TITLE
infra: use a different image to handle port 80

### DIFF
--- a/infrastructure/ecs.tf
+++ b/infrastructure/ecs.tf
@@ -10,10 +10,10 @@ resource "aws_ecs_task_definition" "initiator" {
   container_definitions = jsonencode([
     {
       "name" : "clean-slice",
-      "image" : "nginxdemos/nginx-hello:0.2",
+      "image" : "nginxdemos/hello:0.3",
       "portMappings" : [
         {
-          "containerPort" : 8080,
+          "containerPort" : 80,
           "hostPort" : 80,
           "protocol" : "tcp"
         }


### PR DESCRIPTION
as i was getting this error
> Error: creating ECS Task Definition (clean-slice-task): ClientException: When networkMode=awsvpc, the host ports and container ports in port mappings must match.